### PR TITLE
fix StringIndexOutOfBoundsException

### DIFF
--- a/jspwiki-main/src/main/java/org/apache/wiki/ajax/AjaxUtil.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/ajax/AjaxUtil.java
@@ -62,6 +62,11 @@ public class AjaxUtil extends HttpServlet {
         if( StringUtils.isBlank( path ) ) {
 			return null;
 		}
+
+		// if this is true, there's nothing left to do
+                if (path.endsWith(lastPart))
+                        return lastPart;
+
 		if( !lastPart.endsWith( "/" ) ) {
 			lastPart += "/";
 		}


### PR DESCRIPTION
On Tomcat 9 (I haven't checked other servlet containers) an exception is thrown is path ends with lastPart. Since there's nothing to be done in that case, lastPart is returned.

I don't know if this is the right fix, but it does make it work for me.